### PR TITLE
Verb to quick-load the ball map + vending fix + baseturf fix

### DIFF
--- a/_maps/ball.json
+++ b/_maps/ball.json
@@ -10,7 +10,7 @@
 	"minetype": "none",
 	"traits": [
 		{
-			"Baseturf": "/turf/open/misc/dirt/jungle",
+			"Baseturf": "/turf/open/misc/dirt/station",
 			"Gravity": true,
 			"No Parallax": true
 		},

--- a/modular_event/ball/mapchange.dm
+++ b/modular_event/ball/mapchange.dm
@@ -1,0 +1,3 @@
+ADMIN_VERB(change_to_ball_map, R_SERVER, "Change to Ball Map", "Force the nexte map to the ball map.", ADMIN_CATEGORY_SERVER)
+	SSmap_vote.set_next_map(load_map_config("ball"))
+	message_admins("[key_name_admin(usr)] has changed the next map to the Ball, don't panic.")

--- a/modular_event/base/disable_economy.dm
+++ b/modular_event/base/disable_economy.dm
@@ -8,4 +8,4 @@
 /obj/machinery/vending/Initialize(mapload)
 	. = ..()
 
-	onstation = FALSE
+	all_products_free = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6676,6 +6676,7 @@
 #include "modular_event\ball\bus.dm"
 #include "modular_event\ball\grilles.dm"
 #include "modular_event\ball\ladder.dm"
+#include "modular_event\ball\mapchange.dm"
 #include "modular_event\ball\outdoor_lighting.dm"
 #include "modular_event\ball\plaque.dm"
 #include "modular_event\ball\safe_turfs.dm"


### PR DESCRIPTION
Ball map is obviously not votable so you can't really "change map" onto it. So I just slapped in a verb which loads it directly.

Also does the fix I mentioned a while ago

Also makes sure we don't use a baseturf which creates chasms